### PR TITLE
12 semantic yaml

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,7 +117,7 @@ not a html_document output.
 #### 'return_heading()' (Not exported)
 
 * Returns NULL if heading text is length zero.
-* Returns required heading level and class if text exceeds length zero.
+* Returns p tags styled to emulate headings, as advised in accessibility review.
 
 #### 'sus_alt()'
 

--- a/R/return_heading.R
+++ b/R/return_heading.R
@@ -1,17 +1,21 @@
-#' Return a HTML heading tag of the required level.
+#' Return a HTML p tag formatted to resemble a heading tag.
 #'
-#' Returns a HTML heading tag of any of the available levels (h1, h2, h3 and so
-#' on). The class selectors applied will always include "toc-ignore", but an
-#' additional selector may be included within the class parameter. If an object
-#' of length zero is passed to the txt parameter, NULL is returned.
+#' Returns a HTML heading p tag formatted with inline css to appear like of any
+#' of the available levels (h1, h2, h3 and so on). This approach is in response
+#' to review comments regarding headings that contained no text potentially
+#' confusing screen reader users. The class selectors applied will always
+#' include "toc-ignore", but an additional selector may be included within the
+#' class parameter. If an object of length zero is passed to the txt parameter,
+#' NULL is returned, allowing for vectorised usage.
 #'
-#' @param txt The text to be used as the heading text.
-#' @param lvl A number to be used for the heading level. 1 == tags$h1() and so
+#' @param txt The text to be used as the 'heading' text.
+#' @param lvl A number indicating the heading level. 1 == tags$h1() and so
 #' on.
 #' @param class A character string to use as the first class attribute. Do not
 #' include "toc-ignore", this will be added.
 #'
-#' @return null if txt is length 0 or required heading level with class attr
+#' @return null if txt is length 0 or p tag styled to appear as required heading
+#' level with class attr applied.
 #'
 return_heading <- function(txt, lvl, class) {
   if (length(txt) == 0) {

--- a/R/return_heading.R
+++ b/R/return_heading.R
@@ -14,6 +14,9 @@
 #' @param class A character string to use as the first class attribute. Do not
 #' include "toc-ignore", this will be added.
 #'
+#' @param font_weights A named character vector. Names are heading levels &
+#' numeric values to apply as font weight.
+#'
 #' @return null if txt is length 0 or p tag styled to appear as required heading
 #' level with class attr applied.
 #'

--- a/R/return_heading.R
+++ b/R/return_heading.R
@@ -17,12 +17,21 @@
 #' @return null if txt is length 0 or p tag styled to appear as required heading
 #' level with class attr applied.
 #'
-return_heading <- function(txt, lvl, class) {
+return_heading <- function(txt,
+                           lvl,
+                           class,
+                           font_weights = c("h1" = 38, "h2" = 30, "h3" = 24)) {
   if (length(txt) == 0) {
     return(NULL)
   } else {
-    h_lvl <- paste0("h", lvl)
-    heading <- tags[[h_lvl]](txt, class = paste(class, "toc-ignore"))
+    # assemble the required css styling txt
+    styling <- sprintf(
+      "font-size:%spx; font-weight=500",
+      unname(font_weights[lvl])
+    )
+    # assemble the p tag using the styling above
+    heading <- tags[["p"]](txt, style = styling,
+      class = paste(class, "toc-ignore"))
     return(heading)
   }
 }

--- a/R/return_heading.R
+++ b/R/return_heading.R
@@ -19,5 +19,6 @@ return_heading <- function(txt, lvl, class) {
   } else {
     h_lvl <- paste0("h", lvl)
     heading <- tags[[h_lvl]](txt, class = paste(class, "toc-ignore"))
+    return(heading)
   }
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,5 +1,6 @@
 accesrmd
 accessrmd
+attr
 aut
 behaviour
 bookdown
@@ -58,6 +59,7 @@ tmpfile
 toc
 uk
 utf
+vectorised
 wd
 xaringan
 yaml

--- a/man/return_heading.Rd
+++ b/man/return_heading.Rd
@@ -2,25 +2,29 @@
 % Please edit documentation in R/return_heading.R
 \name{return_heading}
 \alias{return_heading}
-\title{Return a HTML heading tag of the required level.}
+\title{Return a HTML p tag formatted to resemble a heading tag.}
 \usage{
 return_heading(txt, lvl, class)
 }
 \arguments{
-\item{txt}{The text to be used as the heading text.}
+\item{txt}{The text to be used as the 'heading' text.}
 
-\item{lvl}{A number to be used for the heading level. 1 == tags$h1() and so
+\item{lvl}{A number indicating the heading level. 1 == tags$h1() and so
 on.}
 
 \item{class}{A character string to use as the first class attribute. Do not
 include "toc-ignore", this will be added.}
 }
 \value{
-null if txt is length 0 or required heading level with class attr
+null if txt is length 0 or p tag styled to appear as required heading
+level with class attr applied.
 }
 \description{
-Returns a HTML heading tag of any of the available levels (h1, h2, h3 and so
-on). The class selectors applied will always include "toc-ignore", but an
-additional selector may be included within the class parameter. If an object
-of length zero is passed to the txt parameter, NULL is returned.
+Returns a HTML heading p tag formatted with inline css to appear like of any
+of the available levels (h1, h2, h3 and so on). This approach is in response
+to review comments regarding headings that contained no text potentially
+confusing screen reader users. The class selectors applied will always
+include "toc-ignore", but an additional selector may be included within the
+class parameter. If an object of length zero is passed to the txt parameter,
+NULL is returned, allowing for vectorised usage.
 }

--- a/man/return_heading.Rd
+++ b/man/return_heading.Rd
@@ -4,7 +4,7 @@
 \alias{return_heading}
 \title{Return a HTML p tag formatted to resemble a heading tag.}
 \usage{
-return_heading(txt, lvl, class)
+return_heading(txt, lvl, class, font_weights = c(h1 = 38, h2 = 30, h3 = 24))
 }
 \arguments{
 \item{txt}{The text to be used as the 'heading' text.}
@@ -14,6 +14,9 @@ on.}
 
 \item{class}{A character string to use as the first class attribute. Do not
 include "toc-ignore", this will be added.}
+
+\item{font_weights}{A named character vector. Names are heading levels &
+numeric values to apply as font weight.}
 }
 \value{
 null if txt is length 0 or p tag styled to appear as required heading

--- a/tests/testthat/test-assemble_header.R
+++ b/tests/testthat/test-assemble_header.R
@@ -22,19 +22,13 @@ header2 <- assemble_header(
 test_that("Metas render correctly without subtitle", {
   # title is h1
   expect_equal(
-    any(grepl("title toc-ignore", unlist(header1[[4]][[1]]))),
-    any(grepl("h1", unlist(header1[[4]][[1]])))
+    any(grepl("title toc-ignore", unlist(header1[[3]]))),
+    any(grepl("h1", unlist(header1[[3]])))
   )
-  # author is h2
-  expect_equal(
-    any(grepl("author: John Doe", unlist(header1[[4]][[1]]))),
-    any(grepl("h2", unlist(header1[[4]][[1]])))
-  )
-  # date is h2
-  expect_equal(
-    any(grepl("date: March 22, 2005", unlist(header1[[4]][[2]]))),
-    any(grepl("h2", unlist(header1[[4]][[2]])))
-  )
+  # author is set
+  expect_true(any(grepl("author: John Doe", unlist(header1[[4]][[1]]))))
+  # date is set
+  expect_true(any(grepl("date: March 22, 2005", unlist(header1[[4]][[2]]))))
 })
 
 test_that("Metas render correctly with subtitle", {
@@ -43,23 +37,23 @@ test_that("Metas render correctly with subtitle", {
     any(grepl("title toc-ignore", unlist(header2[[3]]))),
     any(grepl("h1", unlist(header2[[3]])))
   )
-  # subtitle is h2
+  # subtitle is p tag
   expect_equal(
     any(grepl(
       "subtitle: More about Habits",
       unlist(header2[[4]][[1]])
     )),
-    any(grepl("h2", unlist(header2[[4]][[1]])))
+    any(grepl("^p$", unlist(header2[[4]][[1]])))
   )
-  # author is h3
+  # author is p tag
   expect_equal(
     any(grepl("author: John Doe", unlist(header2[[4]][[2]]))),
-    any(grepl("h3", unlist(header2[[4]][[2]])))
+    any(grepl("^p$", unlist(header2[[4]][[2]])))
   )
-  # date is h3
+  # date is p tag
   expect_equal(
     any(grepl("date: March 22, 2005", unlist(header2[[4]][[3]]))),
-    any(grepl("h3", unlist(header2[[4]][[3]])))
+    any(grepl("^p$", unlist(header2[[4]][[3]])))
   )
 })
 

--- a/tests/testthat/test-return_headings.R
+++ b/tests/testthat/test-return_headings.R
@@ -10,13 +10,15 @@ test_that("Tag is returned", {
 })
 
 test_that(
-  "lvl results in correct heading tag",
-  expect_true(grepl("h1", unlist(eg_title))[1])
+  "lvl results in correct heading styling",
+  expect_true(grepl("font-size:38px;", eg_title))
 )
+
 test_that(
   "Correct class returned",
-  expect_true(grepl("title toc-ignore", unlist(eg_title))[2])
+  expect_true(grepl("title toc-ignore", eg_title))
 )
+
 test_that(
   "Returns NULL on length zero character",
   expect_null(


### PR DESCRIPTION
Closes #12 

Function returns a h1 heading followed by styled p tags for all other metadata strings. The p tags return inline css to emulate the appearance of the traditional h2/h3 headings. 