### PR TITLE
chore: More cleanup in test teardown phase

### DIFF
--- a/tests/testthat/test-access_rmd.R
+++ b/tests/testthat/test-access_rmd.R
@@ -90,6 +90,14 @@ test_that(
   )
 )
 
+# teardown ----------------------------------------------------------------
+
+temps <- c(test_file, test_toc, out_file, test_dir)
+unlink(temps)
+# files written to temp with access_rmd()
+temp_rmds <- c("error_file.Rmd", "another_error.Rmd", "forgotten_suffix.Rmd")
+unlink(temp_rmds)
+
 # set the wd to test directory
 with(globalenv(), {
   setwd(.old_wd)

--- a/tests/testthat/test-retrieve_rmds.R
+++ b/tests/testthat/test-retrieve_rmds.R
@@ -43,7 +43,9 @@ test_that("recurse = FALSE returns expected length vec", {
   )
 })
 
+# teardown ----------------------------------------------------------------
 
+unlink(c(all_files, all_dirs))
 
 # set the wd to test directory
 with(globalenv(), {


### PR DESCRIPTION
Resolves #16 

`access_rmd()` uses an accessible template with link updated.
Also some minor bug fixes in test suite.